### PR TITLE
feat: make channel preferences configurable via env vars

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -11,6 +11,10 @@ TWILIO_SMS_FROM=+1XXXXXXXXXX
 MY_PHONE_NUMBER=+1XXXXXXXXXX
 GIRLFRIEND_PHONE_NUMBER=+1XXXXXXXXXX
 
+# Channel Preferences (comma-separated: whatsapp, sms, email)
+MY_CHANNELS=whatsapp,sms
+GIRLFRIEND_CHANNELS=sms
+
 # Scheduling Configuration
 TIMEZONE=America/New_York
 MORNING_TIME=07:30

--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ A production-ready daily morning prompt app that sends personalized love message
    MORNING_TIME=07:30
    GIRLFRIEND_SEND_TIME=08:30
 
+   # Channel preferences (comma-separated)
+   MY_CHANNELS=whatsapp,sms
+   GIRLFRIEND_CHANNELS=sms
+
    # Optional email config
    SMTP_HOST=smtp.sendgrid.net
    SMTP_PORT=587
@@ -171,16 +175,19 @@ TIMEZONE=America/New_York
 
 ### Configure Channels
 
-Edit `src/config/questions.ts` to set preferred channels:
+Set preferred channels via environment variables in `.env`:
 
-```typescript
-export const girlfriendProfile: UserProfile = {
-  name: 'Girlfriend',
-  phoneNumber: process.env.GIRLFRIEND_PHONE_NUMBER || '',
-  email: process.env.GIRLFRIEND_EMAIL || '',
-  preferredChannels: ['whatsapp', 'sms', 'email'],  // Pick any combination
-};
+```env
+MY_CHANNELS=whatsapp,sms           # Your preferred channels (comma-separated)
+GIRLFRIEND_CHANNELS=sms            # Girlfriend's preferred channels
 ```
+
+Available channels: `whatsapp`, `sms`, `email`
+
+Example combinations:
+- `whatsapp,sms` - Send via both WhatsApp and SMS
+- `sms` - SMS only
+- `whatsapp,sms,email` - All three channels
 
 ## Usage
 
@@ -381,6 +388,8 @@ Body=Answer text here
 | `TIMEZONE` | Yes | Timezone for scheduling | `America/New_York` |
 | `MORNING_TIME` | Yes | Daily prompt time (24h) | `07:30` |
 | `GIRLFRIEND_SEND_TIME` | No | Girlfriend message time (24h, default: 08:30) | `08:30` |
+| `MY_CHANNELS` | No | Your preferred channels (comma-separated, default: whatsapp,sms) | `whatsapp,sms` |
+| `GIRLFRIEND_CHANNELS` | No | Girlfriend's preferred channels (comma-separated, default: sms) | `sms` |
 | `SMTP_HOST` | No | SMTP server host | `smtp.sendgrid.net` |
 | `SMTP_PORT` | No | SMTP server port | `587` |
 | `SMTP_USER` | No | SMTP username | `apikey` |

--- a/src/config/index.ts
+++ b/src/config/index.ts
@@ -27,6 +27,10 @@ interface Config {
     from: string;
     girlfriendEmail: string;
   };
+  channels: {
+    my: ('whatsapp' | 'sms' | 'email')[];
+    girlfriend: ('whatsapp' | 'sms' | 'email')[];
+  };
 }
 
 const requiredEnvVars = [
@@ -45,6 +49,12 @@ for (const envVar of requiredEnvVars) {
   if (!process.env[envVar]) {
     throw new Error(`Missing required environment variable: ${envVar}`);
   }
+}
+
+// Helper function to parse channel preferences
+function parseChannels(envVar: string | undefined, defaultValue: string): ('whatsapp' | 'sms' | 'email')[] {
+  const channelsStr = envVar || defaultValue;
+  return channelsStr.split(',').map(ch => ch.trim() as 'whatsapp' | 'sms' | 'email');
 }
 
 const config: Config = {
@@ -71,6 +81,10 @@ const config: Config = {
     pass: process.env.SMTP_PASS || '',
     from: process.env.EMAIL_FROM || '',
     girlfriendEmail: process.env.GIRLFRIEND_EMAIL || '',
+  },
+  channels: {
+    my: parseChannels(process.env.MY_CHANNELS, 'whatsapp,sms'),
+    girlfriend: parseChannels(process.env.GIRLFRIEND_CHANNELS, 'sms'),
   },
 };
 

--- a/src/config/questions.ts
+++ b/src/config/questions.ts
@@ -1,3 +1,5 @@
+import config from './index';
+
 export interface Question {
   number: number;
   text: string;
@@ -29,12 +31,12 @@ export const myProfile: UserProfile = {
   name: 'Me',
   phoneNumber: process.env.MY_PHONE_NUMBER || '',
   email: process.env.EMAIL_FROM || '',
-  preferredChannels: ['whatsapp', 'sms'],
+  preferredChannels: config.channels.my,
 };
 
 export const girlfriendProfile: UserProfile = {
   name: 'Girlfriend',
   phoneNumber: process.env.GIRLFRIEND_PHONE_NUMBER || '',
   email: process.env.GIRLFRIEND_EMAIL || '',
-  preferredChannels: ['whatsapp', 'sms', 'email'],
+  preferredChannels: config.channels.girlfriend,
 };


### PR DESCRIPTION
Make channel preferences configurable via environment variables instead of hardcoding them in the source code.

## Changes
- Add MY_CHANNELS and GIRLFRIEND_CHANNELS env vars to src/config/index.ts
- Parse channel preferences as comma-separated arrays of whatsapp, sms, email
- Update myProfile and girlfriendProfile to use config values instead of hardcoded arrays
- Set girlfriend default to SMS-only (no WhatsApp)
- Set my default to whatsapp,sms
- Update .env.example with new channel preference vars
- Update README.md to document new channel configuration via env vars

Closes #7

Generated with [Claude Code](https://claude.ai/code)