### PR TITLE
fix: Copy static files from src/public to dist/public during build

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "ts-node-dev --respawn --transpile-only src/index.ts",
-    "build": "tsc",
+    "build": "tsc && cp -r src/public dist/public",
     "start": "node dist/index.js",
     "type-check": "tsc --noEmit"
   },


### PR DESCRIPTION
Fixes #12

Updated the build script to copy static files from `src/public/` to `dist/public/` after TypeScript compilation.

This resolves the ENOENT error where Railway couldn't find `/app/dist/public/index.html` because the build script was only compiling TypeScript files without copying static assets.

### Changes
- Updated `build` script in package.json from `tsc` to `tsc && cp -r src/public dist/public`

Generated with [Claude Code](https://claude.ai/code)